### PR TITLE
feature/persist comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,4 @@ If want to place `debugger` in Ruby code, need to start server with `bin/rails s
 - [Handling Interaction Payloads](https://api.slack.com/interactivity/handling#payloads)
 - [View Submissin Payload](https://api.slack.com/reference/interaction-payloads/views#view_submission)
 - [Slack User](https://api.slack.com/types/user)
+- [Slash commands and what to respond](https://api.slack.com/interactivity/slash-commands)

--- a/README.md
+++ b/README.md
@@ -99,3 +99,5 @@ If want to place `debugger` in Ruby code, need to start server with `bin/rails s
 - [Blocks Reference](https://api.slack.com/reference/block-kit/blocks)
 - [Modals](https://api.slack.com/surfaces/modals)
 - [Handling Interaction Payloads](https://api.slack.com/interactivity/handling#payloads)
+- [View Submissin Payload](https://api.slack.com/reference/interaction-payloads/views#view_submission)
+- [Slack User](https://api.slack.com/types/user)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -31,6 +31,10 @@ class Comment < ApplicationRecord
 
   validates :content, presence: true
   validates :anonymous, inclusion: { in: [true, false] }
-  validates :slack_user_id, presence: true, unless: :anonymous?
-  validates :slack_username, presence: true, unless: :anonymous?
+
+  # These validations must match the `check_slack_info_if_not_anonymous` check constraint on the `comments` table:
+  validates :slack_user_id, absence: { message: "must be empty when anonymous is true" }, if: :anonymous
+  validates :slack_username, absence: { message: "must be empty when anonymous is true" }, if: :anonymous
+  validates :slack_user_id, presence: { message: "must be provided when anonymous is false" }, unless: :anonymous
+  validates :slack_username, presence: { message: "must be provided when anonymous is false" }, unless: :anonymous
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -6,9 +6,11 @@
 #  anonymous        :boolean          default(FALSE), not null
 #  category         :enum             default("keep"), not null
 #  content          :text             not null
+#  slack_username   :string
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  retrospective_id :bigint           not null
+#  slack_user_id    :string
 #
 # Indexes
 #
@@ -29,4 +31,6 @@ class Comment < ApplicationRecord
 
   validates :content, presence: true
   validates :anonymous, inclusion: { in: [true, false] }
+  validates :slack_user_id, presence: true, unless: :anonymous?
+  validates :slack_username, presence: true, unless: :anonymous?
 end

--- a/bot/actions/view_submission.rb
+++ b/bot/actions/view_submission.rb
@@ -8,13 +8,15 @@ SlackRubyBotServer::Events.configure do |config|
     slack_client = Slack::Web::Client.new(token: team.token)
 
     # Parse payload to extract comment, category, anonymous, slack user id and slack username
+    # If app is receiving multiple different form submissions, check callback_id and handle accordingly
+    callback_id = payload["view"]["callback_id"]
     user_id = payload["user"]["id"]
     category = payload["view"]["state"]["values"]["category_block"]["category_select"]["selected_option"]["value"]
     comment = payload["view"]["state"]["values"]["comment_block"]["comment_input"]["value"]
     anonymous = payload["view"]["state"]["values"]["anonymous_block"]["anonymous_checkbox"]["selected_options"].present?
     slack_user_id = payload["user"]["id"]
     slack_username = payload["user"]["username"]
-    action.logger.info "=== ACTION: User: #{payload['user']['username']}, Cat: #{category}, Anon: #{anonymous}"
+    action.logger.info "=== ACTION: CB: #{callback_id}, U: #{slack_username}, CAT: #{category}, AN: #{anonymous}"
 
     # Find the one open Retrospective model (should only be one!)
     retrospective = Retrospective.find_by(status: "open")

--- a/bot/actions/view_submission.rb
+++ b/bot/actions/view_submission.rb
@@ -20,9 +20,7 @@ SlackRubyBotServer::Events.configure do |config|
     retrospective = Retrospective.find_by(status: "open")
 
     # Only save slack info when anonymous is true.
-    slack_info = anonymous ? { slack_user_id:, slack_username: } : {}
-    # temp debug
-    puts "=== SLACK_INFO = #{slack_info}"
+    slack_info = anonymous ? { slack_user_id: nil, slack_username: nil } : { slack_user_id:, slack_username: }
 
     # Save the new Comment for the Retrospective
     new_comment = Comment.new(

--- a/bot/slash_commands/retro_feedback.rb
+++ b/bot/slash_commands/retro_feedback.rb
@@ -14,11 +14,14 @@ SlackRubyBotServer::Events.configure do |config|
 end
 
 # rubocop:disable Metrics/MethodLength
+# callback_id populated here will come back in view_submission payload as:
+# payload["view"]["callback_id"]. See `bot/actions/view_submission.rb`.
 def modal_payload(trigger_id)
   {
     trigger_id:,
     view: {
       type: "modal",
+      callback_id: "feedback_form",
       title: {
         type: "plain_text",
         text: "Retrospective Feedback",

--- a/db/migrate/20231127134515_add_slack_user_id_to_comments.rb
+++ b/db/migrate/20231127134515_add_slack_user_id_to_comments.rb
@@ -1,0 +1,5 @@
+class AddSlackUserIdToComments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :comments, :slack_user_id, :string
+  end
+end

--- a/db/migrate/20231127134525_add_slack_user_name_to_comments.rb
+++ b/db/migrate/20231127134525_add_slack_user_name_to_comments.rb
@@ -1,0 +1,5 @@
+class AddSlackUserNameToComments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :comments, :slack_username, :string
+  end
+end

--- a/db/migrate/20231127135016_add_check_constraint_for_slack_info_in_comments.rb
+++ b/db/migrate/20231127135016_add_check_constraint_for_slack_info_in_comments.rb
@@ -1,0 +1,11 @@
+class AddCheckConstraintForSlackInfoInComments < ActiveRecord::Migration[7.0]
+  def change
+    # If a comment is not anonymous, then both slack_user_id and slack_username must have values (not be NULL).
+    # If a comment is anonymous, it doesn't enforce the non-null constraint on the slack_user_id and slack_username.
+    add_check_constraint(
+      :comments,
+      "(NOT anonymous) AND (slack_user_id IS NOT NULL AND slack_username IS NOT NULL)",
+      name: "check_slack_info_if_not_anonymous"
+    )
+  end
+end

--- a/db/migrate/20231127135016_add_check_constraint_for_slack_info_in_comments.rb
+++ b/db/migrate/20231127135016_add_check_constraint_for_slack_info_in_comments.rb
@@ -1,10 +1,10 @@
 class AddCheckConstraintForSlackInfoInComments < ActiveRecord::Migration[7.0]
   def change
-    # If a comment is not anonymous, then both slack_user_id and slack_username must have values (not be NULL).
-    # If a comment is anonymous, it doesn't enforce the non-null constraint on the slack_user_id and slack_username.
+    # If a comment is anonymous, then the slack info fields should be null.
+    # If a comment is not anonymous, then the slack info fields should be populated.
     add_check_constraint(
       :comments,
-      "(NOT anonymous) AND (slack_user_id IS NOT NULL AND slack_username IS NOT NULL)",
+      "(anonymous AND slack_user_id IS NULL AND slack_username IS NULL) OR (NOT anonymous AND slack_user_id IS NOT NULL AND slack_username IS NOT NULL)",
       name: "check_slack_info_if_not_anonymous"
     )
   end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,6 +10,13 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: public; Type: SCHEMA; Schema: -; Owner: -
+--
+
+-- *not* creating schema, since initdb creates it
+
+
+--
 -- Name: comment_category; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -57,7 +64,10 @@ CREATE TABLE public.comments (
     retrospective_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    category public.comment_category DEFAULT 'keep'::public.comment_category NOT NULL
+    category public.comment_category DEFAULT 'keep'::public.comment_category NOT NULL,
+    slack_user_id character varying,
+    slack_username character varying,
+    CONSTRAINT check_slack_info_if_not_anonymous CHECK (((NOT anonymous) AND ((slack_user_id IS NOT NULL) AND (slack_username IS NOT NULL))))
 );
 
 
@@ -254,6 +264,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20231003124110'),
 ('20231003125437'),
 ('20231004114901'),
-('20231107124352');
+('20231107124352'),
+('20231127134515'),
+('20231127134525'),
+('20231127135016');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -67,7 +67,7 @@ CREATE TABLE public.comments (
     category public.comment_category DEFAULT 'keep'::public.comment_category NOT NULL,
     slack_user_id character varying,
     slack_username character varying,
-    CONSTRAINT check_slack_info_if_not_anonymous CHECK (((NOT anonymous) AND ((slack_user_id IS NOT NULL) AND (slack_username IS NOT NULL))))
+    CONSTRAINT check_slack_info_if_not_anonymous CHECK (((anonymous AND (slack_user_id IS NULL) AND (slack_username IS NULL)) OR ((NOT anonymous) AND (slack_user_id IS NOT NULL) AND (slack_username IS NOT NULL))))
 );
 
 

--- a/docs/annotate.md
+++ b/docs/annotate.md
@@ -1,0 +1,54 @@
+# Annotate
+
+* https://github.com/ctran/annotate_models/blob/e60a66644e8a8ea5dccd6a398d31f22878233998/lib/tasks/annotate_models.rake#L21
+* https://github.com/search?q=repo%3Actran%2Fannotate_models%20show_check_constraints&type=code
+* https://github.com/ctran/annotate_models/blob/e60a66644e8a8ea5dccd6a398d31f22878233998/lib/annotate/annotate_models.rb#L384
+
+```bash
+bundle exec rake remove_annotation
+
+ANNOTATE_SHOW_CHECK_CONSTRAINTS=1 bundle exec rake annotate_models -c app/models/comment.rb
+ANNOTATE_SHOW_CHECK_CONSTRAINTS=yes bundle exec rake annotate_models -c
+```
+
+```ruby
+def get_check_constraint_info(klass, options = {})
+  cc_info = if options[:format_markdown]
+              "#\n# ### Check Constraints\n#\n"
+            else
+              "#\n# Check Constraints\n#\n"
+            end
+
+  return '' unless klass.connection.respond_to?(:supports_check_constraints?) &&
+    klass.connection.supports_check_constraints? && klass.connection.respond_to?(:check_constraints)
+
+  check_constraints = klass.connection.check_constraints(klass.table_name)
+  return '' if check_constraints.empty?
+
+  max_size = check_constraints.map { |check_constraint| check_constraint.name.size }.max + 1
+  check_constraints.sort_by(&:name).each do |check_constraint|
+    expression = check_constraint.expression ? "(#{check_constraint.expression.squish})" : nil
+
+    cc_info << if options[:format_markdown]
+                  cc_info_markdown = sprintf("# * `%s`", check_constraint.name)
+                  cc_info_markdown << sprintf(": `%s`", expression) if expression
+                  cc_info_markdown << "\n"
+                else
+                  sprintf("#  %-#{max_size}.#{max_size}s %s", check_constraint.name, expression).rstrip + "\n"
+                end
+  end
+
+  cc_info
+end
+
+get_check_constraint_info(Comment)
+# => "#\n# Check Constraints\n#\n#  check_slack_info_if_not_anonymous  (NOT anonymous OR slack_user_id IS NOT NULL AND slack_username IS NOT NULL)\n"
+```
+
+```sql
+INSERT INTO comments (content, anonymous, retrospective_id, created_at, updated_at, category, slack_user_id, slack_username)
+VALUES ('Example Content', false, 6, NOW(), NOW(), 'keep', '123abc', 'john_doe');
+
+INSERT INTO comments (content, anonymous, retrospective_id, created_at, updated_at, category, slack_user_id, slack_username)
+VALUES ('Example Content', false, 6, NOW(), NOW(), 'keep', NULL, NULL);
+```

--- a/docs/sample-view-submission-action-payload.json
+++ b/docs/sample-view-submission-action-payload.json
@@ -1,0 +1,178 @@
+{
+    "type": "view_submission",
+    "team": {
+        "id": "AAA111",
+        "domain": "somegroup"
+    },
+    "user": {
+        "id": "BBB222",
+        "username": "jane.smith",
+        "name": "jane.smith",
+        "team_id": "AAA111"
+    },
+    "api_app_id": "CCC333",
+    "token": "DDD444",
+    "trigger_id": "EEE555",
+    "view": {
+        "id": "FFF666",
+        "team_id": "AAA111",
+        "type": "modal",
+        "blocks": [
+            {
+                "type": "input",
+                "block_id": "category_block",
+                "label": {
+                    "type": "plain_text",
+                    "text": "Category",
+                    "emoji": true
+                },
+                "optional": false,
+                "dispatch_action": false,
+                "element": {
+                    "type": "static_select",
+                    "action_id": "category_select",
+                    "placeholder": {
+                        "type": "plain_text",
+                        "text": "Select category",
+                        "emoji": true
+                    },
+                    "options": [
+                        {
+                            "text": {
+                                "type": "plain_text",
+                                "text": "Something we should keep doing",
+                                "emoji": true
+                            },
+                            "value": "keep"
+                        },
+                        {
+                            "text": {
+                                "type": "plain_text",
+                                "text": "Something we should stop doing",
+                                "emoji": true
+                            },
+                            "value": "stop"
+                        },
+                        {
+                            "text": {
+                                "type": "plain_text",
+                                "text": "Something to try",
+                                "emoji": true
+                            },
+                            "value": "try"
+                        }
+                    ]
+                }
+            },
+            {
+                "type": "input",
+                "block_id": "comment_block",
+                "label": {
+                    "type": "plain_text",
+                    "text": "Comment",
+                    "emoji": true
+                },
+                "optional": false,
+                "dispatch_action": false,
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": "comment_input",
+                    "placeholder": {
+                        "type": "plain_text",
+                        "text": "Enter your feedback",
+                        "emoji": true
+                    },
+                    "multiline": true,
+                    "dispatch_action_config": {
+                        "trigger_actions_on": [
+                            "on_enter_pressed"
+                        ]
+                    }
+                }
+            },
+            {
+                "type": "input",
+                "block_id": "anonymous_block",
+                "label": {
+                    "type": "plain_text",
+                    "text": "Anonymous",
+                    "emoji": true
+                },
+                "optional": true,
+                "dispatch_action": false,
+                "element": {
+                    "type": "checkboxes",
+                    "action_id": "anonymous_checkbox",
+                    "options": [
+                        {
+                            "text": {
+                                "type": "plain_text",
+                                "text": "Yes",
+                                "emoji": true
+                            },
+                            "value": "true"
+                        }
+                    ]
+                }
+            }
+        ],
+        "private_metadata": "",
+        "callback_id": "",
+        "state": {
+            "values": {
+                "category_block": {
+                    "category_select": {
+                        "type": "static_select",
+                        "selected_option": {
+                            "text": {
+                                "type": "plain_text",
+                                "text": "Something we should keep doing",
+                                "emoji": true
+                            },
+                            "value": "keep"
+                        }
+                    }
+                },
+                "comment_block": {
+                    "comment_input": {
+                        "type": "plain_text_input",
+                        "value": "good stuff yay"
+                    }
+                },
+                "anonymous_block": {
+                    "anonymous_checkbox": {
+                        "type": "checkboxes",
+                        "selected_options": []
+                    }
+                }
+            }
+        },
+        "hash": "GGG777",
+        "title": {
+            "type": "plain_text",
+            "text": "Retrospective Feedback",
+            "emoji": true
+        },
+        "clear_on_close": false,
+        "notify_on_close": false,
+        "close": {
+            "type": "plain_text",
+            "text": "Cancel",
+            "emoji": true
+        },
+        "submit": {
+            "type": "plain_text",
+            "text": "Submit",
+            "emoji": true
+        },
+        "previous_view_id": null,
+        "root_view_id": "FFF666",
+        "app_id": "CCC333",
+        "external_id": "",
+        "app_installed_team_id": "AAA111",
+        "bot_id": "HHH888"
+    },
+    "response_urls": [],
+    "is_enterprise_install": false,
+    "enterprise": null
+}

--- a/docs/show-retro.html.erb
+++ b/docs/show-retro.html.erb
@@ -1,0 +1,49 @@
+<!-- app/views/retrospectives/show.html.erb -->
+
+<div class="container mx-auto mt-8">
+  <h1 class="text-4xl font-bold mb-4"><%= @retrospective.title %></h1>
+
+  <div class="grid grid-cols-3 gap-4">
+    <div>
+      <h2 class="text-2xl font-bold mb-2">Keep</h2>
+      <% @retrospective.comments.keep.each do |comment| %>
+        <%= render_card(comment) %>
+      <% end %>
+    </div>
+
+    <div>
+      <h2 class="text-2xl font-bold mb-2">Stop</h2>
+      <% @retrospective.comments.stop.each do |comment| %>
+        <%= render_card(comment) %>
+      <% end %>
+    </div>
+
+    <div>
+      <h2 class="text-2xl font-bold mb-2">Try</h2>
+      <% @retrospective.comments.try.each do |comment| %>
+        <%= render_card(comment) %>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<%# Helper method to render a comment card %>
+<%# You might want to create a new partial, e.g., _comment_card.html.erb, for better organization %>
+<% def render_card(comment) %>
+  <div class="bg-<%= card_color(comment.category) %> rounded p-4 mb-4">
+    <p class="text-gray-600 text-sm">
+      <%= comment.anonymous ? "Anonymous" : comment.slack_username %>
+    </p>
+    <p class="mt-2"><%= comment.content %></p>
+  </div>
+<% end %>
+
+<%# Helper method to determine the card color based on the comment category %>
+<% def card_color(category) %>
+  <% case category %>
+    <% when "keep" then "pink-100" %>
+    <% when "stop" then "yellow-100" %>
+    <% when "try" then "green-100" %>
+    <% else "gray-100" %>
+  <% end %>
+<% end %>

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,8 +1,5 @@
 # TODO
 
-- WIP: Add slack user id to comment and persist if not anonymous
-- WIP: Implement action to handle modal form submission for retro-feedback, always save slack user info (check which fields are deprecated)
-
 - experiment: add vscode rest client and try to submit `POST /api/slack/action` (or /command) with/without valid X-Slack-Signature header to see what breaks, where validation happens within slack server gem
 
 - refactor retro-open slash command handler `bot/slash_commands/retro_open.rb`

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -28,6 +28,8 @@
 - validate/inclusion on all models with enums, error message should include the list of allowed values
 - instead of string values everywhere, reference Model.enum...
 
+- remove unused routes and pending tests
+
 ## Nice to have
 
 - `/retro-feedback` default category to `keep` should be able to do with `initial_option` in [static_select](https://api.slack.com/reference/block-kit/block-elements#static_select) but getting invalid error

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,7 +1,5 @@
 # TODO
 
-- experiment: add vscode rest client and try to submit `POST /api/slack/action` (or /command) with/without valid X-Slack-Signature header to see what breaks, where validation happens within slack server gem
-
 - refactor retro-open slash command handler `bot/slash_commands/retro_open.rb`
   - extract logic to a service: retro creation and construction of response message
   - error handling

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -13,12 +13,13 @@
 - refactor retro-feedback slash command handler (service, error handling) `bot/slash_commands/retro_feedback.rb`
 - refactor view_submission action handler (service, error handling) `bot/actions/view_submission.rb`
 
-- Need action for `/retro-close`
+- Need action for `/retro-close` to close the currently open Retrospective
 
 - Why does it show "Sending messages to this app has been turned off" in Slack when clicking on the Retro Pulse app?
 
 - application layout needs work, especially wrt notices (actually, maybe don't need notices anymore)
 - build retro view: showing keep, stop, and try feedback as cards in columns
+  - retrospectives controller `show` action should `includes` comments
   - if feedback has anon checked, then display anon, otherwise display Slack user
   - nice to have: can we get Slack avatar?
 - welcome index view styling, layout
@@ -35,7 +36,74 @@
 - `/retro-feedback` default category to `keep` should be able to do with `initial_option` in [static_select](https://api.slack.com/reference/block-kit/block-elements#static_select) but getting invalid error
 - `/retro-feedback keep` would pre-populate dropdown with `keep` (similar for `stop` and `try`)
 - text area form label changes based on dropdown value (eg: What should we keep on doing?), see `views.update` in https://api.slack.com/surfaces/modals
+
 - Can user's edit their feedback?
+  - Maybe if send block kit response with button, then need to handle new bot action `block_actions`, then check payload: actions action_id: edit-comment-{comment id}
+  - But then will need to generate a new modal/form prepopulated with content for user to edit, and when it gets submitted, will come in as `view_submission` and will need to distinguish it from regular feedback form. Can do this by specifying `callback_id` alongside `trigger_id`:
+  ```ruby
+  slack_client.views_open(modal_payload(trigger_id, 'your_modal_callback_id'))
+
+  def modal_payload(trigger_id, callback_id)
+  {
+    trigger_id: trigger_id,
+    callback_id: callback_id,  # Set the callback_id here
+    view: {
+      type: "modal",
+  ```
+
+
 - oauth scopes are defined in two places: `app_manifest_template.json` and `config/initializers/slack_ruby_bot_server.rb`
 - Handle 400 error from `POST /api/teams``, eg: { "type": "other_error", "message": "Team foo is already registered.", "backtrace": "..." } or just display whatever message from this endpoint in welcome view
 - if user selected not to be anon in their feedback, display their Slack avatar in the feedback card, [users.profile.get](https://api.slack.com/methods/users.profile.get), then given an avatar_hash: `https://avatars.slack-edge.com/YOUR_WORKSPACE/USER_ID/AVATAR_HASH_512.png`, where YOUR_WORKSPACE is your Slack workspace name, USER_ID is the ID of the user whose avatar you want to retrieve, and AVATAR_HASH_512 is the avatar hash followed by _512.png
+
+### Edit Feedback
+
+From `bot/actions/view_submission.rb`:
+
+Would need to detect is this new feedback form submission or result of editing?
+
+Would need to send back a response with blockkit so an Edit button can be rendered, something like this:
+
+```ruby
+  slack_client.chat_postMessage(
+      channel: user_id,
+      text: message,
+      blocks: [
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": message
+          }
+        },
+        # {
+        #   "type": "header",
+        #   "text": {
+        #     "type": "plain_text",
+        #     "text": "Your feedback",
+        #     "emoji": true
+        #   }
+        # },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": new_comment.content
+          },
+          "accessory": {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "Edit",
+              "emoji": true
+            },
+            "value": "edit-comment-#{new_comment.id}",
+            "action_id": "edit-comment-#{new_comment.id}"
+          }
+        }
+      ]
+    )
+```

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,7 +1,7 @@
 # TODO
 
-- Add slack user id to comment and persist if not anonymous
-- Implement action to handle modal form submission for retro-feedback, always save slack user info (check which fields are deprecated)
+- WIP: Add slack user id to comment and persist if not anonymous
+- WIP: Implement action to handle modal form submission for retro-feedback, always save slack user info (check which fields are deprecated)
 
 - experiment: add vscode rest client and try to submit `POST /api/slack/action` (or /command) with/without valid X-Slack-Signature header to see what breaks, where validation happens within slack server gem
 

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -6,9 +6,11 @@
 #  anonymous        :boolean          default(FALSE), not null
 #  category         :enum             default("keep"), not null
 #  content          :text             not null
+#  slack_username   :string
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  retrospective_id :bigint           not null
+#  slack_user_id    :string
 #
 # Indexes
 #

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -25,5 +25,7 @@ FactoryBot.define do
     retrospective
     content { "MyText" }
     anonymous { false }
+    slack_user_id { "abc123" }
+    slack_username { "jane.smith" }
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -40,16 +40,38 @@ RSpec.describe Comment do
       expect(comment).to have_attributes(anonymous: false)
     end
 
-    it "validates presence of slack_user_id when not anonymous" do
-      comment = described_class.new(anonymous: false, slack_user_id: nil)
+    it "validates absence of slack_user_id when anonymous is true" do
+      comment = described_class.new(anonymous: true, slack_user_id: "abc123")
       comment.valid?
-      expect(comment.errors[:slack_user_id]).to include("can't be blank")
+      expect(comment.errors[:slack_user_id]).to include("must be empty when anonymous is true")
     end
 
-    it "validates presence of slack_username when not anonymous" do
+    it "validates absence of slack_username when anonymous is true" do
+      comment = described_class.new(anonymous: true, slack_username: "jane.smith")
+      comment.valid?
+      expect(comment.errors[:slack_username]).to include("must be empty when anonymous is true")
+    end
+
+    it "validates presence of slack_user_id when anonymous is false" do
+      comment = described_class.new(anonymous: false, slack_user_id: nil)
+      comment.valid?
+      expect(comment.errors[:slack_user_id]).to include("must be provided when anonymous is false")
+    end
+
+    it "validates presence of slack_username when anonymous is false" do
       comment = described_class.new(anonymous: false, slack_username: nil)
       comment.valid?
-      expect(comment.errors[:slack_username]).to include("can't be blank")
+      expect(comment.errors[:slack_username]).to include("must be provided when anonymous is false")
+    end
+
+    it "is valid when anonymous is false and slack info is populated" do
+      comment = build_stubbed(:comment, anonymous: false, slack_user_id: "abc123", slack_username: "jane.smith")
+      expect(comment).to be_valid
+    end
+
+    it "is valid when anonymous is true and slack info is not populated" do
+      comment = build_stubbed(:comment, anonymous: true, slack_user_id: nil, slack_username: nil)
+      expect(comment).to be_valid
     end
   end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -6,9 +6,11 @@
 #  anonymous        :boolean          default(FALSE), not null
 #  category         :enum             default("keep"), not null
 #  content          :text             not null
+#  slack_username   :string
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  retrospective_id :bigint           not null
+#  slack_user_id    :string
 #
 # Indexes
 #
@@ -36,6 +38,18 @@ RSpec.describe Comment do
 
     it "has a default value of false for anonymous" do
       expect(comment).to have_attributes(anonymous: false)
+    end
+
+    it "validates presence of slack_user_id when not anonymous" do
+      comment = described_class.new(anonymous: false, slack_user_id: nil)
+      comment.valid?
+      expect(comment.errors[:slack_user_id]).to include("can't be blank")
+    end
+
+    it "validates presence of slack_username when not anonymous" do
+      comment = described_class.new(anonymous: false, slack_username: nil)
+      comment.valid?
+      expect(comment.errors[:slack_username]).to include("can't be blank")
     end
   end
 

--- a/spec/models/retrospective_spec.rb
+++ b/spec/models/retrospective_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe Retrospective do
         create(:retrospective, status: "open")
         retro2 = described_class.new(title: "foo", status: "open")
         retro2.valid?
-        puts "retro2 errors: #{retro2.errors.full_messages}"
         expect(retro2.errors[:status]).to include("There can only be one open retrospective at a time.")
       end
     end


### PR DESCRIPTION
- add slack info to comments and enforce if not anonymous
- fix comments table constraint wrt anon and slack info, wip on persisting feedback from Slack modal submission
- fix anonymous handling wrt saving or not saving slack info on Comment model
- save some notes for nice to have feature of editing feedback from slack
- save some brainstorming on displaying retro in columns and cards
- add callback_id to modal to know which form is being submitted
- clear out done experiment
